### PR TITLE
개행문자를 포함하고 있으면 문자열 전체를 개행문자로 바꿔버리는 부분 제거

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1304,17 +1304,6 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
       const childLines = concat(
         path.map(function (childPath: any) {
-          const child = childPath.getValue();
-
-          if (
-            namedTypes.Literal.check(child) &&
-            typeof child.value === "string"
-          ) {
-            if (/\n/.test(child.value)) {
-              return "\n";
-            }
-          }
-
           return print(childPath);
         }, "children"),
       ).indentTail(options.tabWidth);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "LenditKr <engineering@lendit.co.kr>",
   "name": "@lenditkr/recast",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "description": "JavaScript syntax tree transformer, nondestructive pretty-printer, and automatic source map generator",
   "keywords": [
     "ast",


### PR DESCRIPTION
## 설명
 
JSXElement 에 children으로 들어가 있는데 여기서 "\n"으로 바꾸는게 원인입니다.
아예 노드 자체를 날려버리네요..